### PR TITLE
fix: add legacy main resolver for CDN/Webpack4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Size](https://img.shields.io/badge/dynamic/json?style=flat&colorA=000000&colorB=000000&label=gzip&query=$.size.compressedSize&url=https://deno.bundlejs.com/?q=fourwastaken)](https://unpkg.com/fourwastaken)
+[![Size](https://img.shields.io/badge/dynamic/json?label=gzip&style=flat&colorA=000000&colorB=000000&query=$.size.compressedSize&url=https://deno.bundlejs.com/?q=fourwastaken)](https://unpkg.com/fourwastaken)
 [![Version](https://img.shields.io/npm/v/fourwastaken?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/fourwastaken)
 [![Downloads](https://img.shields.io/npm/dt/fourwastaken.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/fourwastaken)
 
@@ -33,15 +33,27 @@ Minimal three.js alternative.
 
 ## Installation
 
-To install, use your preferred package manager:
+To install, use your preferred package manager or CDN:
+
+```bash
+npm install fourwastaken
+yarn add fourwastaken
+pnpm add fourwastaken
+```
+
+```html
+<script type="module">
+  import * as FOUR from 'https://unpkg.com/fourwastaken'
+</script>
+```
+
+You can optionally install under the `four` alias:
 
 ```bash
 npm install four@npm:fourwastaken
 yarn add four@npm:fourwastaken
 pnpm add four@npm:fourwastaken
 ```
-
-This will install `fourwastaken` as `four`; both will be available.
 
 ```ts
 import * as FOUR from 'four'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Size](https://img.shields.io/bundlephobia/minzip/fourwastaken?label=gzip&style=flat&colorA=000000&colorB=000000)](https://bundlephobia.com/package/fourwastaken)
+[![Size](https://img.shields.io/badge/dynamic/json?style=flat&colorA=000000&colorB=000000&label=gzip&query=$.size.compressedSize&url=https://deno.bundlejs.com/?q=fourwastaken)](https://unpkg.com/fourwastaken)
 [![Version](https://img.shields.io/npm/v/fourwastaken?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/fourwastaken)
 [![Downloads](https://img.shields.io/npm/dt/fourwastaken.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/fourwastaken)
 

--- a/README.md
+++ b/README.md
@@ -36,27 +36,15 @@ Minimal three.js alternative.
 To install, use your preferred package manager or CDN:
 
 ```bash
-npm install fourwastaken
-yarn add fourwastaken
-pnpm add fourwastaken
+npm install four@npm:fourwastaken
+yarn add four@npm:fourwastaken
+pnpm add four@npm:fourwastaken
 ```
 
 ```html
 <script type="module">
   import * as FOUR from 'https://unpkg.com/fourwastaken'
 </script>
-```
-
-You can optionally install under the `four` alias:
-
-```bash
-npm install four@npm:fourwastaken
-yarn add four@npm:fourwastaken
-pnpm add four@npm:fourwastaken
-```
-
-```ts
-import * as FOUR from 'four'
 ```
 
 > **Note**: Vite may have issues consuming WebGPU code which relies on top-level await via ESM. This is well supported since 2021, but you may need to use [vite-plugin-top-level-await](https://github.com/Menci/vite-plugin-top-level-await) to use this library with `vite.optimizeDeps`.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "src/*"
   ],
   "type": "module",
+  "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "sideEffects": false,
   "devDependencies": {


### PR DESCRIPTION
Follow-up to #7. Mirrors https://github.com/oframe/ogl/pull/174.

Vite and Bundlephobia still choke on the use of top-level await in #5 which is the only withstanding issue. Not addressable, although this incidentally works around https://github.com/pastelsky/bundlephobia/issues/639.